### PR TITLE
GenICam adaptions to support IDS USB3 cameras with IDS-specific pixel format

### DIFF
--- a/GenICam/PFNC.h
+++ b/GenICam/PFNC.h
@@ -476,6 +476,7 @@ typedef enum PfncFormat_
   BayerRG12Packed                          = 0x010C002B, /* GigE Vision specific format, Bayer Red-Green 12-bit packed */
   RGB10V1Packed                            = 0x0220001C, /* GigE Vision specific format, Red-Green-Blue 10-bit packed - variant 1 */
   RGB12V1Packed                            = 0x02240034, /* GigE Vision specific format, Red-Green-Blue 12-bit packed - variant 1 */
+  PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS = 0x40000001, /* temporarily added. IDS specific */
   InvalidPixelFormat                       = 0
 } PfncFormat;
 
@@ -753,6 +754,7 @@ static PFNC_INLINE const char* GetPixelFormatName (PfncFormat format)
     case BayerRG12Packed:                         return "BayerRG12Packed";
     case RGB10V1Packed:                           return "RGB10V1Packed";
     case RGB12V1Packed:                           return "RGB12V1Packed";
+    case PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS: return "BayerRG10G40"; /* temporarily added, IDS specific */
 
     case InvalidPixelFormat: return "InvalidPixelFormat";
 

--- a/GenICam/basePort.cpp
+++ b/GenICam/basePort.cpp
@@ -1532,7 +1532,7 @@ QVector<PfncFormat> BasePort::supportedImageFormats(QVector<int> *bitdepths /*= 
         m_supportedFormatsColor << 0     << 0      << 0            << 0       << 0      << 0            << 0       << 0      << 0      << 1    << 1          << 1    << 1      << 1      << 1;
 
         // add IDS imaging specific values
-        m_supportedFormats << PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS; // PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS
+        m_supportedFormats << PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS;
         m_supportedFormatsBpp << 10;
         m_supportedFormatsColor << 1;
 

--- a/GenICam/basePort.cpp
+++ b/GenICam/basePort.cpp
@@ -1448,20 +1448,33 @@ ito::RetVal BasePort::syncImageParameters(QMap<QString, ito::Param> &params, QSh
             pEnum->GetEntries(nodes);
             QByteArray val;
             bool found = false;
+            CEnumEntryPtr enumItem;
+            EAccessMode enumAccessMode;
+
             for (int i = 0; i < nodes.size(); ++i)
             {
-                val = ((CEnumEntryPtr)nodes[i])->GetSymbolic();
-                if (m_supportedFormatsNames.contains(val))
+                enumItem = (CEnumEntryPtr)nodes[i];
+
+                if (enumItem)
                 {
-                    *pEnum = val.constData();
-                    //pEnum->SetIntValue(((CEnumEntryPtr)nodes[i])->GetNumericValue());
-                    idx = m_supportedFormatsNames.indexOf(QLatin1String(val));
-                    it->setVal<int>(m_supportedFormatsBpp[idx]);
-                    intMeta->setMin(m_supportedFormatsBpp[idx]);
-                    intMeta->setMax(m_supportedFormatsBpp[idx]);
-                    itColor->setVal<int>(m_supportedFormatsColor[idx]);
-                    found = true;
-                    break;
+                    val = enumItem->GetSymbolic();
+                    enumAccessMode = enumItem->GetAccessMode();
+
+                    if (enumAccessMode > NA)
+                    {
+                        if (m_supportedFormatsNames.contains(val))
+                        {
+                            *pEnum = val.constData();
+                            //pEnum->SetIntValue(((CEnumEntryPtr)nodes[i])->GetNumericValue());
+                            idx = m_supportedFormatsNames.indexOf(QLatin1String(val));
+                            it->setVal<int>(m_supportedFormatsBpp[idx]);
+                            intMeta->setMin(m_supportedFormatsBpp[idx]);
+                            intMeta->setMax(m_supportedFormatsBpp[idx]);
+                            itColor->setVal<int>(m_supportedFormatsColor[idx]);
+                            found = true;
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -1517,6 +1530,11 @@ QVector<PfncFormat> BasePort::supportedImageFormats(QVector<int> *bitdepths /*= 
         m_supportedFormats      << Mono8 << Mono10 << Mono10Packed << Mono10p << Mono12 << Mono12Packed << Mono12p << Mono14 << Mono16 << RGB8 << YCbCr422_8 << BGR8 << BGR10p << BGR12p << BayerRG8;
         m_supportedFormatsBpp   << 8     << 10     << 10           << 10      << 12     << 12           << 12      << 14     << 16     << 8    << 8          << 8    << 10     << 12     << 8;
         m_supportedFormatsColor << 0     << 0      << 0            << 0       << 0      << 0            << 0       << 0      << 0      << 1    << 1          << 1    << 1      << 1      << 1;
+
+        // add IDS imaging specific values
+        m_supportedFormats << PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS; // PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS
+        m_supportedFormatsBpp << 10;
+        m_supportedFormatsColor << 1;
 
         for (int i = 0; i < m_supportedFormats.size(); ++i)
         {

--- a/GenICam/basePort.cpp
+++ b/GenICam/basePort.cpp
@@ -278,7 +278,7 @@ ito::RetVal BasePort::connectToGenApi(ito::uint32 portIndex)
 
     if (url.toLower().startsWith("local:"))
     {
-        QRegularExpression regExp("^local:(///)?([a-zA-Z0-9\\._\\- "
+        QRegularExpression regExp("^local:(///)?([a-zA-Z0-9@\\._\\- "
             "]+);([A-Fa-f0-9]+);([A-Fa-f0-9]+)(\\?SchemaVersion=.+)?$",
             QRegularExpression::CaseInsensitiveOption);
 

--- a/GenICam/dataStream.cpp
+++ b/GenICam/dataStream.cpp
@@ -1567,28 +1567,34 @@ ito::RetVal GenTLDataStream::copyMono8ToDataObject(
     const size_t& width,
     const size_t& height,
     bool littleEndian,
-    ito::DataObject& dobj)
+    ito::DataObject& dobj,
+    bool considerModelWorkarounds /*= true*/)
 {
     size_t real_height = height;
 
-    // some IDS camera models have additional image lines at the front, which are black and
-    // are skipped by IDS Peak. Here, we have to do this manually!
-    switch (m_specialModelType)
+    if (considerModelWorkarounds)
     {
-    case IDS_U3_38Jx:
-        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
-        //real_height -= 38;
-        real_height = dobj.getSize(0); // safer
-        ptr += 38 * width * 5 / 4;
-        break;
-    case IDS_U3_33Fx:
-        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
-        //real_height -= 65;
-        real_height = dobj.getSize(0); // safer
-        ptr += 65 * width * 5 / 4;
-        break;
-    default:
-        break;
+        // some IDS camera models have additional image lines at the front, which are black and
+        // are skipped by IDS Peak. Here, we have to do this manually!
+        switch (m_specialModelType)
+        {
+        case IDS_U3_38Jx:
+            // see
+            // https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
+            // real_height -= 38;
+            real_height = dobj.getSize(0); // safer
+            ptr += 38 * width * 5 / 4;
+            break;
+        case IDS_U3_33Fx:
+            // see
+            // https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
+            // real_height -= 65;
+            real_height = dobj.getSize(0); // safer
+            ptr += 65 * width * 5 / 4;
+            break;
+        default:
+            break;
+        }
     }
 
     // little or big endian is idle for mono8:
@@ -1727,29 +1733,35 @@ ito::RetVal GenTLDataStream::copyBayerRG8ToColorDataObject(
     const size_t& width,
     const size_t& height,
     bool littleEndian,
-    ito::DataObject& dobj)
+    ito::DataObject& dobj,
+    bool considerModelWorkarounds /*= true*/)
 {
     ito::RetVal retVal = ito::retOk;
     size_t real_height = height;
 
-    // some IDS camera models have additional image lines at the front, which are black and
-    // are skipped by IDS Peak. Here, we have to do this manually!
-    switch (m_specialModelType)
+    if (considerModelWorkarounds)
     {
-    case IDS_U3_38Jx:
-        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
-        //real_height -= 38;
-        real_height = dobj.getSize(0); // safer
-        ptr += 38 * width;
-        break;
-    case IDS_U3_33Fx:
-        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
-        //real_height -= 65;
-        real_height = dobj.getSize(0); // safer
-        ptr += 65 * width;
-        break;
-    default:
-        break;
+        // some IDS camera models have additional image lines at the front, which are black and
+        // are skipped by IDS Peak. Here, we have to do this manually!
+        switch (m_specialModelType)
+        {
+        case IDS_U3_38Jx:
+            // see
+            // https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
+            // real_height -= 38;
+            real_height = dobj.getSize(0); // safer
+            ptr += 38 * width;
+            break;
+        case IDS_U3_33Fx:
+            // see
+            // https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
+            // real_height -= 65;
+            real_height = dobj.getSize(0); // safer
+            ptr += 65 * width;
+            break;
+        default:
+            break;
+        }
     }
 
     cv::Mat sourceImage = cv::Mat(real_height, width, CV_8UC1, (void*)ptr);
@@ -1783,30 +1795,41 @@ ito::RetVal GenTLDataStream::copyBayerRG8ToColorDataObject(
 }
 
 //-------------------------------------------------------------------------------------
-ito::RetVal GenTLDataStream::copyBayerRG10G40IDSToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj)
+ito::RetVal GenTLDataStream::copyBayerRG10G40IDSToColorDataObject(
+    const char* ptr, 
+    const size_t& width, 
+    const size_t& height, 
+    bool littleEndian, 
+    ito::DataObject& dobj,
+    bool considerModelWorkarounds /*= true*/)
 {
     // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/basics-raw-bayer-pixel-formats.html
 
     int real_height = height;
 
-    // some IDS camera models have additional image lines at the front, which are black and
-    // are skipped by IDS Peak. Here, we have to do this manually!
-    switch (m_specialModelType)
+    if (considerModelWorkarounds)
     {
-    case IDS_U3_38Jx:
-        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
-        //real_height -= 38;
-        real_height = dobj.getSize(0); // safer
-        ptr += 38 * width * 5 / 4;
-        break;
-    case IDS_U3_33Fx:
-        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
-        //real_height -= 65;
-        real_height = dobj.getSize(0); // safer
-        ptr += 65 * width * 5 / 4;
-        break;
-    default:
-        break;
+        // some IDS camera models have additional image lines at the front, which are black and
+        // are skipped by IDS Peak. Here, we have to do this manually!
+        switch (m_specialModelType)
+        {
+        case IDS_U3_38Jx:
+            // see
+            // https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
+            // real_height -= 38;
+            real_height = dobj.getSize(0); // safer
+            ptr += 38 * width * 5 / 4;
+            break;
+        case IDS_U3_33Fx:
+            // see
+            // https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
+            // real_height -= 65;
+            real_height = dobj.getSize(0); // safer
+            ptr += 65 * width * 5 / 4;
+            break;
+        default:
+            break;
+        }
     }
 
     if (m_charBuffer_cache.size() < width * real_height)
@@ -1835,7 +1858,8 @@ ito::RetVal GenTLDataStream::copyBayerRG10G40IDSToColorDataObject(const char* pt
         ptr += 5;
     }
 
-    auto retVal = copyBayerRG8ToColorDataObject(bayerRG8PtrStart, width, real_height, littleEndian, dobj);
+    // do not allow model modifications, since already considered in this method
+    auto retVal = copyBayerRG8ToColorDataObject(bayerRG8PtrStart, width, real_height, littleEndian, dobj, false);
 
     return retVal;
 }

--- a/GenICam/dataStream.cpp
+++ b/GenICam/dataStream.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     Plugin "GenICam" for itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2022, Institut für Technische Optik (ITO),
+    Copyright (C) 2024, Institut für Technische Optik (ITO),
     Universität Stuttgart, Germany
 
     This file is part of a plugin for the measurement software itom.
@@ -36,11 +36,12 @@
 
 //----------------------------------------------------------------------------------------------------------------------------------
 GenTLDataStream::GenTLDataStream(
-    QSharedPointer<QLibrary> lib, GenTL::DS_HANDLE handle, int verbose, ito::RetVal& retval) :
+    QSharedPointer<QLibrary> lib, GenTL::DS_HANDLE handle, const QByteArray& modelName, int verbose, ito::RetVal& retval) :
     m_handle(handle),
     m_lib(lib), m_newBufferEvent(GENTL_INVALID_HANDLE), m_errorEvent(GENTL_INVALID_HANDLE),
     m_acquisitionStarted(false), m_payloadSize(0), m_timeoutMS(0), m_usePreAllocatedBuffer(-1),
-    m_endianessChanged(true), m_verbose(verbose), m_flushAllBuffersToInput(false)
+    m_endianessChanged(true), m_verbose(verbose), m_flushAllBuffersToInput(false),
+    m_modelName(modelName)
 {
     GCRegisterEvent = (GenTL::PGCRegisterEvent)m_lib->resolve("GCRegisterEvent");
     GCUnregisterEvent = (GenTL::PGCUnregisterEvent)m_lib->resolve("GCUnregisterEvent");
@@ -53,6 +54,7 @@ GenTLDataStream::GenTLDataStream(
     DSGetBufferInfo = (GenTL::PDSGetBufferInfo)m_lib->resolve("DSGetBufferInfo");
     DSStartAcquisition = (GenTL::PDSStartAcquisition)m_lib->resolve("DSStartAcquisition");
     DSStopAcquisition = (GenTL::PDSStopAcquisition)m_lib->resolve("DSStopAcquisition");
+    DSGetBufferChunkData = (GenTL::PDSGetBufferChunkData)m_lib->resolve("DSGetBufferChunkData");
     DSGetInfo = (GenTL::PDSGetInfo)m_lib->resolve("DSGetInfo");
     DSAllocAndAnnounceBuffer =
         (GenTL::PDSAllocAndAnnounceBuffer)m_lib->resolve("DSAllocAndAnnounceBuffer");
@@ -1153,6 +1155,49 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
     pSize = sizeof(height);
     auto errHeight =
         DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_HEIGHT, &dtype, &height, &pSize);
+
+    /*size_t ttt;
+    pSize = sizeof(ttt);
+    auto errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_XOFFSET, &dtype, &ttt, &pSize);
+    pSize = sizeof(ttt);
+    errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_YOFFSET, &dtype, &ttt, &pSize);
+    pSize = sizeof(ttt);
+    errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_XPADDING, &dtype, &ttt, &pSize);
+    pSize = sizeof(ttt);
+    errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_YPADDING, &dtype, &ttt, &pSize);
+    bool containsChunkdata;
+    pSize = sizeof(containsChunkdata);
+    errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_CONTAINS_CHUNKDATA, &dtype, &containsChunkdata, &pSize);
+
+    if (containsChunkdata)
+    {
+        size_t chunkListSize = 0;
+        errrr = DSGetBufferChunkData(m_handle, buffer, 0, &chunkListSize);
+
+        if (errrr == GenTL::GC_ERR_SUCCESS && chunkListSize > 0)
+        {
+            GenTL::SINGLE_CHUNK_DATA *chunkdata = new GenTL::SINGLE_CHUNK_DATA[chunkListSize];
+
+            errrr = DSGetBufferChunkData(m_handle, buffer, chunkdata, &chunkListSize);
+
+            delete[] chunkdata;
+        }
+    }
+
+    pSize = sizeof(ttt);
+    errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_DELIVERED_IMAGEHEIGHT, &dtype, &ttt, &pSize);
+    pSize = sizeof(ttt);
+    errrr =
+        DSGetBufferInfo(m_handle, buffer, GenTL::BUFFER_INFO_DELIVERED_CHUNKPAYLOADSIZE, &dtype, &ttt, &pSize);*/
+
+    int dims = dobj.getDims();
+
     if (errWidth == GenTL::GC_ERR_NOT_AVAILABLE || errWidth == GenTL::GC_ERR_NO_DATA ||
         errHeight == GenTL::GC_ERR_NOT_AVAILABLE || errHeight == GenTL::GC_ERR_NO_DATA)
     {
@@ -1160,12 +1205,15 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
         // available, although the image is properly acquired. It might be that this occurs
         // mainly, if chunk data is enabled. Then, the payload type is also not image but
         // chunk.
-        int dims = dobj.getDims();
         width = dobj.getSize(dims - 1);
         height = dobj.getSize(dims - 2);
     }
     else
     {
+        // hint: height can be higher than requested, since there are some models (e.g. from IDS),
+        // where a certain number of first lines have to be skipped.
+        // e.g. see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
+        // or https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
         retval += checkGCError(errWidth, "request width of image buffer");
         retval += checkGCError(errHeight, "request height of image buffer");
     }
@@ -1208,6 +1256,11 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
                 "request pointer of image buffer: returned value is not of expected type (ptr)");
         }
     }
+
+    /*QFile file("D:/temp/ids_data.dat");
+    file.open(QIODeviceBase::WriteOnly);
+    file.write(ptr, size);
+    file.close();*/
 
     if (!retval.containsError())
     {
@@ -1353,7 +1406,7 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
                 dobj);
             break;
         case PFNC_RGB8:
-            retval += copyRGB8ToDataObject(
+            retval += copyRGB8ToColorDataObject(
                 ptr + buffer_offset,
                 width,
                 height,
@@ -1361,7 +1414,7 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
                 dobj);
             break;
         case PFNC_BGR8:
-            retval += copyBGR8ToDataObject(
+            retval += copyBGR8ToColorDataObject(
                 ptr + buffer_offset,
                 width,
                 height,
@@ -1369,7 +1422,7 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
                 dobj);
             break;
         case PFNC_YCbCr422_8:
-            retval += copyYCbCr422ToDataObject(
+            retval += copyYCbCr422ToColorDataObject(
                 ptr + buffer_offset,
                 width,
                 height,
@@ -1377,7 +1430,7 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
                 dobj);
             break;
         case PFNC_BayerRG8:
-            retval += copyBayerRG8ToDataObject(
+            retval += copyBayerRG8ToColorDataObject(
                 ptr + buffer_offset,
                 width,
                 height,
@@ -1439,6 +1492,16 @@ ito::RetVal GenTLDataStream::copyBufferToDataObject(
                 endianness == GenTL::PIXELENDIANNESS_LITTLE,
                 dobj);
             break;
+        case PEAK_IPL_PIXEL_FORMAT_BAYER_RG_10_GROUPED_40_IDS:
+            // please consider that height must be reduced for IDS U3-33Fx by 65 lines
+            // and U3-38Jx by 38 lines.
+            retval += copyBayerRG10G40IDSToColorDataObject(
+                ptr + buffer_offset,
+                width,
+                height,
+                endianness == GenTL::PIXELENDIANNESS_LITTLE,
+                dobj);
+            break;
         case PFNC_BGR10p:
             retval += copyMono10pToDataObject(
                 ptr + buffer_offset,
@@ -1474,7 +1537,7 @@ ito::RetVal GenTLDataStream::copyMono8ToDataObject(
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
-ito::RetVal GenTLDataStream::copyRGB8ToDataObject(
+ito::RetVal GenTLDataStream::copyRGB8ToColorDataObject(
     const char* ptr,
     const size_t& width,
     const size_t& height,
@@ -1511,7 +1574,7 @@ ito::RetVal GenTLDataStream::copyRGB8ToDataObject(
 }
 
 // BGR8 data to RGBa8 DataObject output
-ito::RetVal GenTLDataStream::copyBGR8ToDataObject(
+ito::RetVal GenTLDataStream::copyBGR8ToColorDataObject(
     const char* ptr,
     const size_t& width,
     const size_t& height,
@@ -1546,8 +1609,8 @@ ito::RetVal GenTLDataStream::copyBGR8ToDataObject(
     return ito::retOk;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
-ito::RetVal GenTLDataStream::copyYCbCr422ToDataObject(
+//-------------------------------------------------------------------------------------
+ito::RetVal GenTLDataStream::copyYCbCr422ToColorDataObject(
     const char* ptr,
     const size_t& width,
     const size_t& height,
@@ -1599,8 +1662,8 @@ ito::RetVal GenTLDataStream::copyYCbCr422ToDataObject(
     return ito::retOk;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
-ito::RetVal GenTLDataStream::copyBayerRG8ToDataObject(
+//-------------------------------------------------------------------------------------
+ito::RetVal GenTLDataStream::copyBayerRG8ToColorDataObject(
     const char* ptr,
     const size_t& width,
     const size_t& height,
@@ -1610,6 +1673,7 @@ ito::RetVal GenTLDataStream::copyBayerRG8ToDataObject(
     ito::RetVal retVal = ito::retOk;
 
     cv::Mat sourceImage = cv::Mat(height, width, CV_8UC1, (void*)ptr);
+
     cv::Mat rgbImage;
 #if (CV_MAJOR_VERSION > 3)
     cv::cvtColor(sourceImage, rgbImage, cv::COLOR_BayerRG2BGR, 3);
@@ -1638,7 +1702,62 @@ ito::RetVal GenTLDataStream::copyBayerRG8ToDataObject(
     return ito::retOk;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
+ito::RetVal GenTLDataStream::copyBayerRG10G40IDSToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj)
+{
+    // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/basics-raw-bayer-pixel-formats.html
+
+    int real_height = height;
+
+    // some IDS camera models have additional image lines at the front, which are black and
+    // are skipped by IDS Peak. Here, we have to do this manually!
+    if (m_modelName.startsWith("U3-38Jx"))
+    {
+        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html
+        //real_height -= 38;
+        real_height = dobj.getSize(0); // safer
+        ptr += 38 * width * 5 / 4;
+    }
+    else if (m_modelName.startsWith("U3-33Fx"))
+    {
+        // see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html
+        //real_height -= 65;
+        real_height = dobj.getSize(0); // safer
+        ptr += 65 * width * 5 / 4;
+    }
+
+    if (m_charBuffer_cache.size() < width * real_height)
+    {
+        m_charBuffer_cache.resize(width * real_height);
+    }
+
+    const char* bayerRG8PtrStart = m_charBuffer_cache.data();
+    char* bayerRG8Ptr = (char*)bayerRG8PtrStart;
+
+    // The input ptr has the following form: [R1_8bit, G2_8bit, R3_8bit, G4_8bit, RG14_2bit, G5_8bit, B6_8bit, G7_8bit, B8_8bit, GB58_2bit...]
+    // RG14_2bit are the two LSB bits of R1, G2, R3, G4...
+    // here: we are reducing the 10bit bitdepth to 8bit, therefore the RG14_2bit, GB58_2bit value is ignored (since LSB).
+    int num_40bit_packages = width * real_height / 4;
+
+    for (int i = 0; i < num_40bit_packages; ++i)
+    {
+        // slower:
+        /*bayerRG8Ptr[i * 4] = ptr[i * 5];
+        bayerRG8Ptr[i * 4 + 1] = ptr[i * 5 + 1];
+        bayerRG8Ptr[i * 4 + 2] = ptr[i * 5 + 2];
+        bayerRG8Ptr[i * 4 + 3] = ptr[i * 5 + 3];*/
+        // faster:
+        memcpy(bayerRG8Ptr, ptr, 4 * sizeof(char));
+        bayerRG8Ptr += 4;
+        ptr += 5;
+    }
+
+    auto retVal = copyBayerRG8ToColorDataObject(bayerRG8PtrStart, width, real_height, littleEndian, dobj);
+
+    return retVal;
+}
+
+//-------------------------------------------------------------------------------------
 void msb_to_lsb_16bit(const ito::uint16* source, ito::uint16* dest, size_t n)
 {
     const ito::uint16* end = source + n;
@@ -1651,7 +1770,7 @@ void msb_to_lsb_16bit(const ito::uint16* source, ito::uint16* dest, size_t n)
     }
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 ito::RetVal GenTLDataStream::copyMono10to16ToDataObject(
     const char* ptr,
     const size_t& width,
@@ -1672,7 +1791,7 @@ ito::RetVal GenTLDataStream::copyMono10to16ToDataObject(
     }
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 void unpack_12Packed_into_16_lsb(ito::uint16* dest, const ito::uint8* source, size_t n)
 {
     // http://softwareservices.ptgrey.com/BFS-PGE-16S2/latest/Model/public/ImageFormatControl.html
@@ -1693,7 +1812,7 @@ void unpack_12Packed_into_16_lsb(ito::uint16* dest, const ito::uint8* source, si
     }
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 void unpack_12p_into_16_lsb(ito::uint16* dest, const ito::uint8* source, size_t n)
 {
     // http://softwareservices.ptgrey.com/BFS-PGE-16S2/latest/Model/public/ImageFormatControl.html

--- a/GenICam/dataStream.h
+++ b/GenICam/dataStream.h
@@ -87,6 +87,13 @@ protected:
 
     void printBufferInfo(const char *prefix, GenTL::BUFFER_HANDLE buffer);
 
+    enum SpecialModelType
+    {
+        NoSpecialType,
+        IDS_U3_38Jx,
+        IDS_U3_33Fx
+    };
+
     GenTL::DS_HANDLE m_handle;
     GenTL::EVENT_HANDLE m_newBufferEvent;
     GenTL::EVENT_HANDLE m_errorEvent;
@@ -117,6 +124,7 @@ protected:
     int m_verbose;
     bool m_flushAllBuffersToInput; //see init parameter with the same name
     QByteArray m_modelName;
+    SpecialModelType m_specialModelType; // some models require some special data treatment. This member is for a fast lookup of this.
 
     std::vector<char> m_charBuffer_cache;
 

--- a/GenICam/dataStream.h
+++ b/GenICam/dataStream.h
@@ -42,7 +42,7 @@
 class GenTLDataStream
 {
 public:
-    GenTLDataStream(QSharedPointer<QLibrary> lib, GenTL::DS_HANDLE handle, int verbose, ito::RetVal &retval);
+    GenTLDataStream(QSharedPointer<QLibrary> lib, GenTL::DS_HANDLE handle, const QByteArray &modelName, int verbose, ito::RetVal &retval);
     ~GenTLDataStream();
 
     ito::RetVal allocateAndAnnounceBuffers(int nrOfBuffers, size_t bytesPerBuffer = 0); //bytesPerBuffer = 0 means that the payload for each buffer should be automatically detected
@@ -72,10 +72,11 @@ public:
 
 protected:
     ito::RetVal copyMono8ToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
-    ito::RetVal copyRGB8ToDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
-    ito::RetVal copyBGR8ToDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
-    ito::RetVal copyYCbCr422ToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
-    ito::RetVal copyBayerRG8ToDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
+    ito::RetVal copyRGB8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
+    ito::RetVal copyBGR8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
+    ito::RetVal copyYCbCr422ToColorDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
+    ito::RetVal copyBayerRG8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
+    ito::RetVal copyBayerRG10G40IDSToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
     ito::RetVal copyMono10to16ToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
     ito::RetVal copyMono12pToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
     ito::RetVal copyMono12PackedToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
@@ -99,6 +100,7 @@ protected:
     GenTL::PDSQueueBuffer DSQueueBuffer;
     GenTL::PDSFlushQueue DSFlushQueue;
     GenTL::PDSGetBufferInfo DSGetBufferInfo;
+    GenTL::PDSGetBufferChunkData DSGetBufferChunkData;
     GenTL::PDSClose DSClose;
     GenTL::PDSStartAcquisition DSStartAcquisition;
     GenTL::PDSStopAcquisition DSStopAcquisition;
@@ -114,6 +116,9 @@ protected:
     bool m_endianessChanged;
     int m_verbose;
     bool m_flushAllBuffersToInput; //see init parameter with the same name
+    QByteArray m_modelName;
+
+    std::vector<char> m_charBuffer_cache;
 
 };
 

--- a/GenICam/dataStream.h
+++ b/GenICam/dataStream.h
@@ -71,12 +71,12 @@ public:
     }
 
 protected:
-    ito::RetVal copyMono8ToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
+    ito::RetVal copyMono8ToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj, bool considerModelWorkarounds = true);
     ito::RetVal copyRGB8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
     ito::RetVal copyBGR8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
     ito::RetVal copyYCbCr422ToColorDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
-    ito::RetVal copyBayerRG8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
-    ito::RetVal copyBayerRG10G40IDSToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj);
+    ito::RetVal copyBayerRG8ToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj, bool considerModelWorkarounds = true);
+    ito::RetVal copyBayerRG10G40IDSToColorDataObject(const char* ptr, const size_t& width, const size_t& height, bool littleEndian, ito::DataObject& dobj, bool considerModelWorkarounds = true);
     ito::RetVal copyMono10to16ToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
     ito::RetVal copyMono12pToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);
     ito::RetVal copyMono12PackedToDataObject(const char* ptr, const size_t &width, const size_t &height, bool littleEndian, ito::DataObject &dobj);

--- a/GenICam/device.cpp
+++ b/GenICam/device.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     Plugin "GenICam" for itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2018, Institut für Technische Optik (ITO),
+    Copyright (C) 2024, Institut für Technische Optik (ITO),
     Universität Stuttgart, Germany
 
     This file is part of a plugin for the measurement software itom.
@@ -42,13 +42,21 @@ using namespace GENICAM_NAMESPACE;
 
 
 //----------------------------------------------------------------------------------------------------------------------------------
-GenTLDevice::GenTLDevice(QSharedPointer<QLibrary> lib, GenTL::DEV_HANDLE devHandle, const QByteArray &deviceID, const QByteArray& modelName, const QByteArray &identifier, int verbose, ito::RetVal &retval) :
+GenTLDevice::GenTLDevice(
+    QSharedPointer<QLibrary> lib,
+    GenTL::DEV_HANDLE devHandle,
+    const QByteArray &deviceID,
+    const QByteArray& modelName,
+    const QByteArray &identifier,
+    const QByteArray& serialNumber,
+    int verbose,
+    ito::RetVal &retval) :
     BasePort(lib, BasePort::TypeCamera, verbose, retval),
     m_cameraHandle(devHandle),
     m_deviceID(deviceID),
     m_modelName(modelName),
     m_identifier(identifier),
-
+    m_serialNumber(serialNumber),
     m_errorEvent(GENTL_INVALID_HANDLE)
 {
     if (!retval.containsError())

--- a/GenICam/device.cpp
+++ b/GenICam/device.cpp
@@ -42,10 +42,11 @@ using namespace GENICAM_NAMESPACE;
 
 
 //----------------------------------------------------------------------------------------------------------------------------------
-GenTLDevice::GenTLDevice(QSharedPointer<QLibrary> lib, GenTL::DEV_HANDLE devHandle, QByteArray deviceID, const QByteArray &identifier, int verbose, ito::RetVal &retval) :
+GenTLDevice::GenTLDevice(QSharedPointer<QLibrary> lib, GenTL::DEV_HANDLE devHandle, const QByteArray &deviceID, const QByteArray& modelName, const QByteArray &identifier, int verbose, ito::RetVal &retval) :
     BasePort(lib, BasePort::TypeCamera, verbose, retval),
     m_cameraHandle(devHandle),
     m_deviceID(deviceID),
+    m_modelName(modelName),
     m_identifier(identifier),
 
     m_errorEvent(GENTL_INVALID_HANDLE)
@@ -160,7 +161,7 @@ QSharedPointer<GenTLDataStream> GenTLDevice::getDataStream(ito::int32 streamInde
                         std::cout << "OK\n" << std::endl;
                     }
 
-                    stream = QSharedPointer<GenTLDataStream>(new GenTLDataStream(m_lib, streamHandle, m_verbose, retval));
+                    stream = QSharedPointer<GenTLDataStream>(new GenTLDataStream(m_lib, streamHandle, m_modelName, m_verbose, retval));
                     if (retval.containsError())
                     {
                         stream.clear();

--- a/GenICam/device.h
+++ b/GenICam/device.h
@@ -61,12 +61,16 @@ public:
         const QByteArray &deviceID,
         const QByteArray &modelName,
         const QByteArray &identifier,
+        const QByteArray &serialNumber,
         int verbose,
         ito::RetVal &retval);
 
     ~GenTLDevice();
 
     QByteArray getDeviceID() const { return m_deviceID; }
+
+    //!< returns the serial number of this device or an empty string if not available
+    QByteArray getSerialNumber() const { return m_serialNumber; }
 
     QSharedPointer<GenTLDataStream> getDataStream(ito::int32 streamIndex, ito::RetVal &retval);
 
@@ -84,6 +88,7 @@ protected:
     QSharedPointer<QTimer> m_callbackParameterChangedTimer;
     GenTL::DEV_HANDLE m_cameraHandle;
     QByteArray m_deviceID;
+    QByteArray m_serialNumber;
     QByteArray m_identifier;
     QByteArray m_modelName;
     GenTL::EVENT_HANDLE m_errorEvent;

--- a/GenICam/device.h
+++ b/GenICam/device.h
@@ -55,7 +55,15 @@ using namespace GENAPI_NAMESPACE;
 class GenTLDevice : public BasePort
 {
 public:
-    GenTLDevice(QSharedPointer<QLibrary> lib, GenTL::DEV_HANDLE devHandle, QByteArray deviceID, const QByteArray &identifier, int verbose, ito::RetVal &retval);
+    GenTLDevice(
+        QSharedPointer<QLibrary> lib,
+        GenTL::DEV_HANDLE devHandle,
+        const QByteArray &deviceID,
+        const QByteArray &modelName,
+        const QByteArray &identifier,
+        int verbose,
+        ito::RetVal &retval);
+
     ~GenTLDevice();
 
     QByteArray getDeviceID() const { return m_deviceID; }
@@ -77,6 +85,7 @@ protected:
     GenTL::DEV_HANDLE m_cameraHandle;
     QByteArray m_deviceID;
     QByteArray m_identifier;
+    QByteArray m_modelName;
     GenTL::EVENT_HANDLE m_errorEvent;
 };
 

--- a/GenICam/deviceContainer.cpp
+++ b/GenICam/deviceContainer.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     Plugin "GenICam" for itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2018, Institut für Technische Optik (ITO),
+    Copyright (C) 2024, Institut für Technische Optik (ITO),
     Universität Stuttgart, Germany
 
     This file is part of a plugin for the measurement software itom.
@@ -22,8 +22,6 @@
 
 #include "deviceContainer.h"
 
-
-
 #include "gccommon.h"
 
 #include <qfileinfo.h>
@@ -32,17 +30,18 @@
 #include "common/sharedStructures.h"
 #include <iostream>
 
-/*static*/ GenTLOrganizer *GenTLOrganizer::m_pOrganizer = NULL;
+/*static*/ GenTLOrganizer *GenTLOrganizer::m_pOrganizer = nullptr;
+/*static*/ const QByteArray GenTLInterface::SerialNumberPrefix = "Serial:";
 //----------------------------------------------------------------------------------------------------------------------------------
 
 /*static*/ GenTLOrganizer * GenTLOrganizer::instance(void)
 {
     static GenTLOrganizerSingleton w;
-    if (GenTLOrganizer::m_pOrganizer == NULL)
+    if (GenTLOrganizer::m_pOrganizer == nullptr)
     {
         #pragma omp critical
         {
-            if (GenTLOrganizer::m_pOrganizer == NULL)
+            if (GenTLOrganizer::m_pOrganizer == nullptr)
             {
                 GenTLOrganizer::m_pOrganizer = new GenTLOrganizer();
             }
@@ -88,13 +87,13 @@ QSharedPointer<GenTLSystem> GenTLOrganizer::getSystem(const QString &filename, i
 
 //----------------------------------------------------------------------------------------------------------------------------------
 GenTLSystem::GenTLSystem() :
-    GCInitLib(NULL),
-    GCCloseLib(NULL),
-    GCGetInfo(NULL),
-    GCGetLastError(NULL),
-    TLOpen(NULL),
-    TLClose(NULL),
-    TLUpdateInterfaceList(NULL),
+    GCInitLib(nullptr),
+    GCCloseLib(nullptr),
+    GCGetInfo(nullptr),
+    GCGetLastError(nullptr),
+    TLOpen(nullptr),
+    TLClose(nullptr),
+    TLUpdateInterfaceList(nullptr),
     m_initialized(false),
     m_systemInit(false),
     m_systemOpened(false),
@@ -112,7 +111,7 @@ GenTLSystem::~GenTLSystem()
         if (TLClose && m_systemOpened)
         {
             TLClose(m_handle);
-            m_handle = NULL;
+            m_handle = nullptr;
         }
 
         if (GCCloseLib && m_systemInit)
@@ -537,12 +536,23 @@ int GenTLInterface::getNumDevices() const
     }
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------
 /*
 \param deviceID: ID of device to be opened, if empty, the first available device is used.
 */
-QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID, GenTL::DEVICE_ACCESS_FLAGS deviceAccess, ito::RetVal &retval)
+QSharedPointer<GenTLDevice> GenTLInterface::getDevice(
+    const QByteArray &deviceID,
+    GenTL::DEVICE_ACCESS_FLAGS deviceAccess,
+    ito::RetVal &retval)
 {
+    bool fetchSerialNumberNotDeviceID = deviceID.startsWith(SerialNumberPrefix);
+    QByteArray requestedSerialNumber = "";
+
+    if (fetchSerialNumberNotDeviceID)
+    {
+        requestedSerialNumber = deviceID.mid(SerialNumberPrefix.size());
+    }
+
     if (!IFGetDeviceInfo)
     {
         retval += ito::RetVal(ito::retError, 0, "System not initialized");
@@ -556,11 +566,28 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
         {
             if (m_devices[i].isNull() == false)
             {
-                usedDeviceIDs.insert(m_devices[i].toStrongRef().data()->getDeviceID());
+                const auto dev = m_devices[i].toStrongRef();
 
-                if (m_devices[i].toStrongRef().data()->getDeviceID() == deviceID)
+                usedDeviceIDs.insert(dev->getDeviceID());
+
+                if (fetchSerialNumberNotDeviceID)
                 {
-                    retval += ito::RetVal::format(ito::retError,0,"device '%s' already in use", deviceID.constData());
+                    if (requestedSerialNumber != "" && dev->getSerialNumber() == requestedSerialNumber)
+                    {
+                        retval += ito::RetVal::format(
+                            ito::retError,
+                            0,
+                            "device with serial number '%s' already in use",
+                            requestedSerialNumber.constData()
+                        );
+                    }
+                }
+                else
+                {
+                    if (dev->getDeviceID() == deviceID)
+                    {
+                        retval += ito::RetVal::format(ito::retError, 0, "device '%s' already in use", deviceID.constData());
+                    }
                 }
             }
         }
@@ -586,17 +613,19 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
 
             for (uint32_t i = 0; i < piNumDevices; ++i)
             {
+                piSize = 512;
                 localRetVal = checkGCError(IFGetDeviceID(m_handle, i, sDeviceID, &piSize));
 
                 //check access status
                 GenTL::DEVICE_ACCESS_STATUS accessStatus = GenTL::DEVICE_ACCESS_STATUS_UNKNOWN;
+                QByteArray deviceSerialNumber(200, ' ');
 
                 if (!localRetVal.containsError())
                 {
                     GenTL::INFO_DATATYPE piType;
                     char pBuffer[512];
-                    size_t piSize = sizeof(pBuffer);
-                    GenTL::GC_ERROR err = IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_ACCESS_STATUS, &piType, &pBuffer, &piSize);
+                    size_t piSize2 = sizeof(pBuffer);
+                    GenTL::GC_ERROR err = IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_ACCESS_STATUS, &piType, &pBuffer, &piSize2);
 
                     if (err == GenTL::GC_ERR_SUCCESS && piType == GenTL::INFO_DATATYPE_INT32)
                     {
@@ -623,6 +652,17 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                             "that this camera can be accessed!",
                             sDeviceID);
                     }
+
+
+                    piSize2 = deviceSerialNumber.size();
+                    if (IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_SERIAL_NUMBER, &piType, deviceSerialNumber.data(), &piSize2) != GenTL::GC_ERR_SUCCESS)
+                    {
+                        deviceSerialNumber = "";
+                    }
+                    else
+                    {
+                        deviceSerialNumber = deviceSerialNumber.left(piSize2 - 1);
+                    }
                 }
 
                 if (!localRetVal.containsError())
@@ -635,7 +675,11 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                     {
                         found = true;
                     }
-                    else if (deviceID == sDeviceID)
+                    else if (fetchSerialNumberNotDeviceID && deviceSerialNumber == requestedSerialNumber)
+                    {
+                        found = true;
+                    }
+                    else if (!fetchSerialNumberNotDeviceID && deviceID == sDeviceID)
                     {
                         found = true;
                     }
@@ -668,8 +712,8 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
             {
                 //try to open the interface with the given interfaceID
                 sDeviceID[0] = '\0';
-                memcpy(sDeviceID, deviceID.constData(), sizeof(char) * std::min<int>(deviceID.size(),(int)piSize));
-                sDeviceID[piSize-1] = '\0';
+                memcpy(sDeviceID, deviceID.constData(), sizeof(char) * std::min<int>(deviceID.size(), (int)piSize));
+                sDeviceID[piSize - 1] = '\0';
             }
 
             if (m_verbose >= VERBOSE_INFO)
@@ -710,7 +754,7 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
             if (!retval.containsError())
             {
                 GenTL::INFO_DATATYPE piType;
-                QByteArray id(200, '\0');
+                QByteArray id(200, ' ');
                 piSize = id.size();
                 if (IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_ID, &piType, id.data(), &piSize) != GenTL::GC_ERR_SUCCESS)
                 {
@@ -718,10 +762,10 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                 }
                 else
                 {
-                    id = id.left(piSize);
+                    id = id.left(piSize - 1);
                 }
 
-                QByteArray vendor(200, '\0');
+                QByteArray vendor(200, ' ');
                 piSize = vendor.size();
                 if (IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_VENDOR, &piType, vendor.data(), &piSize) != GenTL::GC_ERR_SUCCESS)
                 {
@@ -729,10 +773,10 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                 }
                 else
                 {
-                    vendor = vendor.left(piSize);
+                    vendor = vendor.left(piSize - 1);
                 }
 
-                QByteArray model(200, '\0');
+                QByteArray model(200, ' ');
                 piSize = model.size();
                 if (IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_MODEL, &piType, model.data(), &piSize) != GenTL::GC_ERR_SUCCESS)
                 {
@@ -740,10 +784,21 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                 }
                 else
                 {
-                    model = model.left(piSize);
+                    model = model.left(piSize - 1);
                 }
 
-                QByteArray identifier(200, '\0');
+                QByteArray serialNumber(200, ' ');
+                piSize = serialNumber.size();
+                if (IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_SERIAL_NUMBER, &piType, serialNumber.data(), &piSize) != GenTL::GC_ERR_SUCCESS)
+                {
+                    serialNumber = "";
+                }
+                else
+                {
+                    serialNumber = serialNumber.left(piSize - 1);
+                }
+
+                QByteArray identifier(200, ' ');
                 piSize = identifier.size();
                 if (IFGetDeviceInfo(m_handle, sDeviceID, GenTL::DEVICE_INFO_DISPLAYNAME, &piType, identifier.data(), &piSize) != GenTL::GC_ERR_SUCCESS)
                 {
@@ -751,7 +806,8 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                 }
                 else
                 {
-                    identifier = identifier.left(piSize);
+                    identifier = identifier.left(piSize - 1);
+
                     if (m_verbose >= VERBOSE_INFO)
                     {
                         std::cout << "OK. Device '" << identifier.constData() << "' opened.\n" << std::endl;
@@ -761,19 +817,21 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                 if (vendor != "" && model != "")
                 {
                     identifier = (QLatin1String(vendor) + " " + QLatin1String(model)).toLatin1();
+
                     if (id != "")
                     {
                         identifier += " (" + QString::fromLatin1(id).toLatin1() + ")";
                     }
                 }
 
-                qDebug() << id << vendor << model << identifier;
+                qDebug() << id << vendor << model << identifier << serialNumber;
 
 
-                GenTLDevice *gtld = new GenTLDevice(m_lib, devHandle, sDeviceID, model, identifier, m_verbose, retval);
+                GenTLDevice *gtld = new GenTLDevice(m_lib, devHandle, sDeviceID, model, identifier, serialNumber, m_verbose, retval);
+
                 if (!retval.containsError())
                 {
-                    return QSharedPointer<GenTLDevice>( gtld );
+                    return QSharedPointer<GenTLDevice>(gtld);
                 }
                 else
                 {

--- a/GenICam/deviceContainer.cpp
+++ b/GenICam/deviceContainer.cpp
@@ -770,7 +770,7 @@ QSharedPointer<GenTLDevice> GenTLInterface::getDevice(const QByteArray &deviceID
                 qDebug() << id << vendor << model << identifier;
 
 
-                GenTLDevice *gtld = new GenTLDevice(m_lib, devHandle, sDeviceID, identifier, m_verbose, retval);
+                GenTLDevice *gtld = new GenTLDevice(m_lib, devHandle, sDeviceID, model, identifier, m_verbose, retval);
                 if (!retval.containsError())
                 {
                     return QSharedPointer<GenTLDevice>( gtld );

--- a/GenICam/deviceContainer.h
+++ b/GenICam/deviceContainer.h
@@ -1,7 +1,7 @@
 /* ********************************************************************
     Plugin "GenICam" for itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2018, Institut für Technische Optik (ITO),
+    Copyright (C) 2024, Institut für Technische Optik (ITO),
     Universität Stuttgart, Germany
 
     This file is part of a plugin for the measurement software itom.
@@ -53,6 +53,8 @@ public:
     int getNumDevices() const;
 
     QSharedPointer<GenTLDevice> getDevice(const QByteArray &deviceID, GenTL::DEVICE_ACCESS_FLAGS deviceAccess, ito::RetVal &retval);
+
+    static const QByteArray SerialNumberPrefix;
 
 protected:
     ito::RetVal printDeviceInfo(const char* sDeviceID) const;

--- a/GenICam/docs/genicam.rst
+++ b/GenICam/docs/genicam.rst
@@ -126,6 +126,22 @@ In the example of an Active Silicon CoaXPress framegrabber, you have to set the 
 **Fg_IncomingHeight** to the **Height** of the camera and **Fg_IncomingPixelFormat** to the current pixel format of the camera. Then adjust the
 values **Fg_Width**, **Fg_Height** and **Fg_PixelFormat** to suitable values, since these values are read by itom to configure a proper image acquisition.
 
+IDS Imaging Development Systems specific adaptions
+==================================================
+
+We recognized, that the device ID of IDS camera is not persistent and might change, e.g. after a re-initialization. Therefore, it is more convenient to
+start such a camera, as well as all other cameras, by their serial number instead of the device ID. To do this, use the deviceID initialization parameter
+and write "Serial:<your serial number>". If the prefix "Serial:" is recognized, the rest of the string is used to detect a camera with this specific
+serial number instead of the device ID.
+
+Additionally, IDS provides some easy cameras, which do (only) support IDS specific pixel formats, e.g. BayerRG10g40IDS (see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/basics-raw-bayer-pixel-formats.html).
+itom supports the IDS specific color format BayerRG10g40IDS. Some camera sensors of IDS cameras have another specific behaviour, such that they
+deliver a certain amount of additional black lines at the beginning of every image. These additional lines are skipped by this plugin, such that
+the real requested image size is provided. The following rules are implemented:
+
+* cameras, whose model name starts with U3-38J: 38 lines are skipped (see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-38jx.html)
+* cameras, whose model name starts with U3-33F: 65 lines are skipped (see https://www.1stvision.com/cameras/IDS/IDS-manuals/en/application-notes-u3-33fx.html)
+
 Compilation
 ===========
 

--- a/GenICam/genicam.cpp
+++ b/GenICam/genicam.cpp
@@ -1,7 +1,7 @@
 /* ********************************************************************
     Plugin "GenICam" for itom software
     URL: http://www.uni-stuttgart.de/ito
-    Copyright (C) 2022, Institut für Technische Optik (ITO),
+    Copyright (C) 2024, Institut für Technische Optik (ITO),
     Universität Stuttgart, Germany
 
     This file is part of a plugin for the measurement software itom.
@@ -79,9 +79,12 @@ Indicate the right interface or leave 'interface' empty, in order to get a list 
 In order to keep this plugin compatible to other camera plugins, the additional parameters 'integration_time', 'roi', 'sizex', 'sizey', \n\
 and 'bpp' are added to the plugin are kept synchronized with 'ExposureTime', 'Width', 'Height', 'OffsetX', 'OffsetY' or 'PixelFormat'. \n\
 \n\
-Up to now the following pixel formats are supported: Mono8, Mono10, Mono10p, Mono10Packed, Mono12, Mono12p, Mono12Packed, Mono14, Mono16, YCbCr422_8, RGB8, BGR8, BGR10p, BGR12p, BayerRG8. \n\
+Up to now the following pixel formats are supported: Mono8, Mono10, Mono10p, Mono10Packed, Mono12, Mono12p, Mono12Packed, Mono14, Mono16, \n\
+YCbCr422_8, RGB8, BGR8, BGR10p, BGR12p, BayerRG8, BayerRG10g40IDS (IDS specific). \n\
 In order to operate framegrabber-based cameras (CoaXPress, Camera Link) with this plugin, please read the additional information in the \n\
 documentation of this plugin. \n\
+Colored pixel formats, with a single-color bitdepth of more than 8 bit are reduced to 8bit per color, since rgba32 is the single color \n\
+datatype of itom.dataObject. \n\
 \n\
 This plugin has been tested with the following cameras: \n\
 \n\
@@ -98,7 +101,8 @@ This plugin has been tested with the following cameras: \n\
 * Ximea (USB3) \n\
 * IDS Imaging, U3-3200SE-M-GL (USB3) \n\
 * IDS Imaging, U3-3800SE-M-GL (USB3) \n\
-* IDS Imaging, UI-5880CP-M-GL (GigE)";
+* IDS Imaging, UI-5880CP-M-GL (GigE) \n\
+* IDS Imaging, U3-38J0XLE-C-HQ (USB3, only format BayerRG10g40IDS)";
     m_detaildescription = QObject::tr(docstring);
 
     m_author = PLUGIN_AUTHOR;
@@ -124,7 +128,9 @@ a list of all auto-detected vendors and models is returned.");
 
     paramVal = ito::Param("deviceID", ito::ParamBase::String, "",
         tr("name of the device to be opened. Leave empty to open first detected device of given "
-            "transport layer and interface.").toLatin1().constData());
+            "transport layer and interface. Some cameras don't have a persistent device ID. "
+            "Then, it is better to identify them with their serial number. If this is desired "
+            "this parameter can also be set to 'Serial:your_serial_number'.").toLatin1().constData());
     m_initParamsOpt.append(paramVal);
 
     paramVal = ito::Param("streamIndex", ito::ParamBase::Int, 0, std::numeric_limits<int>::max(), 0,
@@ -166,10 +172,6 @@ GenICamInterface::~GenICamInterface()
     m_initParamsOpt.clear();
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------
-
-
-//----------------------------------------------------------------------------------------------------------------------------------
 
 //----------------------------------------------------------------------------------------------------------------------------------
 GenICamClass::GenICamClass() : AddInGrabber(),
@@ -234,10 +236,6 @@ GenICamClass::GenICamClass() : AddInGrabber(),
     QVector<ito::Param> pOpt = QVector<ito::Param>();
     QVector<ito::Param> pOut = QVector<ito::Param>();
     registerExecFunc("resyncAllParameters", pMand, pOpt, pOut, tr("Forces a resychroniziation of all camera parameters."));
-
-    //registerExecFunc("special1", pMand, pOpt, pOut, tr("Test for CoaXPress camera with Active Silicon FireBird."));
-    //registerExecFunc("special2", pMand, pOpt, pOut, tr("Test for CoaXPress camera with Active Silicon FireBird."));
-
 
     if (hasGuiSupport())
     {

--- a/GenICam/genicam.cpp
+++ b/GenICam/genicam.cpp
@@ -86,6 +86,10 @@ documentation of this plugin. \n\
 Colored pixel formats, with a single-color bitdepth of more than 8 bit are reduced to 8bit per color, since rgba32 is the single color \n\
 datatype of itom.dataObject. \n\
 \n\
+Please notice, that some cameras require more than one allocator buffer (see parameter 'numBuffers'). Sometimes, it is better to \n\
+set the parameter 'AcquisitionMode' to 'SingleFrame' instead of 'Continuous'. If a camera is not robustly working, try to change \n\
+these parameters before starting the device. \n\
+\n\
 This plugin has been tested with the following cameras: \n\
 \n\
 * Allied Vision, Manta (Firewire) \n\
@@ -102,7 +106,9 @@ This plugin has been tested with the following cameras: \n\
 * IDS Imaging, U3-3200SE-M-GL (USB3) \n\
 * IDS Imaging, U3-3800SE-M-GL (USB3) \n\
 * IDS Imaging, UI-5880CP-M-GL (GigE) \n\
-* IDS Imaging, U3-38J0XLE-C-HQ (USB3, only format BayerRG10g40IDS)";
+* IDS Imaging, U3-38J0XLE-C-HQ (USB3, only format BayerRG10g40IDS) \n\
+* IDS Imaging, U3-3280CP-C-HQ Rev 2.2 (USB3) \n\
+* IDS Imaging, U3-3280CP-M-GL Rev 2.2 (USB3)";
     m_detaildescription = QObject::tr(docstring);
 
     m_author = PLUGIN_AUTHOR;


### PR DESCRIPTION
This pull request brings mainly support for the "special" IDS cameras of the model families U3-38Jx and U3-33Fx. Some of these cameras only support an IDS specific color pixel format (RG10G40IDS).

Additionally, IDS cameras do not have a stable device ID, meaning that this IDS might change from "time-to-time", e.g. after a re-initialization. Therefore, it is better to initialize a specific cameras based on its serial number. To do this, use the deviceID init parameter and write "Serial:<your serial number>".

@photoniker : could you maybe check if this version also work with cameras, that you are using in your setups?