### PR TITLE
Select channel to read from for OphirPower meters.

### DIFF
--- a/OphirPowermeter/OphirPowermeter.h
+++ b/OphirPowermeter/OphirPowermeter.h
@@ -102,6 +102,10 @@ class OphirPowermeter : public ito::AddInDataIO
         char* TCharToChar(const TCHAR* message);
 
         ito::RetVal checkError(const int &e, const char *message);
+        ito::RetVal getMeasurementHeadInfo();
+        ito::RetVal getWavelengthInfo();
+        ito::RetVal getMeasurementMode();
+        ito::RetVal setupStream();
 
     public slots:
         //!< Get Camera-Parameter
@@ -148,7 +152,7 @@ protected:
 
 public:
     OphirPowermeterInterface();
-    ~OphirPowermeterInterface() {};
+    ~OphirPowermeterInterface();
     ito::RetVal getAddInInst(ito::AddInBase **addInInst);
 
 private:


### PR DESCRIPTION
Implemented option to select the channel to read from. Only one channel is available at a time.
Refactored code from the init function for correct behavior in case of a channel change via setParam.
Maybe extended to read from multiple channels at the same time in future (requires change to a bunch of parameters). 